### PR TITLE
PP-6218 Filter out empty values

### DIFF
--- a/src/transformers/GovUKPayPaymentEventMessage.test.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.test.ts
@@ -1,18 +1,21 @@
 import GovUKPayPaymentEventMessage from './GovUKPayPaymentEventMessage'
 describe('message formatter', () => {
 	const messageFromS3Csv = {
-		'transaction_id': 'some-transaction-id',
+		'transaction_id': ' some-transaction-id',
 		'event_date': 'some-event-date',
 		'parent_transaction_id': 'some-parent-transaction-id',
 		'event_name': 'some-event-type',
 		'transaction_type': 'some-resource-type',
 		'reference': 'some-reference',
-		'amount': 'some-amount'
+		'amount': 'some-amount',
+		'will_have_empty_space': ' some-empty-space-values ',
+		'value_omitted': '',
+		'value_included': 'some-value'
 	}
 	const messageBuilder = new GovUKPayPaymentEventMessage()
 
 	test('correctly transforms known reserved columns', () => {
-		const formatted = messageBuilder.transform(messageFromS3Csv)
+		const formatted = messageBuilder.transform({ ...messageFromS3Csv })
 		const body = JSON.parse(formatted.MessageBody)
 
 		expect(body).toHaveProperty('resource_external_id')
@@ -32,10 +35,26 @@ describe('message formatter', () => {
 	})
 
 	test('correctly formats well formatted flat message', () => {
-		const formatted = messageBuilder.transform(messageFromS3Csv)
+		const formatted = messageBuilder.transform({ ...messageFromS3Csv })
 		const body = JSON.parse(formatted.MessageBody)
 
 		expect(body.event_details.reference).toBe('some-reference')
 		expect(body.event_details.amount).toBe('some-amount')
+	})
+
+	test('correctly strips empty space from both reserved and custom properties', () => {
+		const formatted = messageBuilder.transform({ ...messageFromS3Csv })
+		const body = JSON.parse(formatted.MessageBody)
+
+		expect(body.resource_external_id).toBe('some-transaction-id')
+		expect(body.event_details.will_have_empty_space).toBe('some-empty-space-values')
+	})
+
+	test('correctly ignores values from rows that have omitted values', () => {
+		const formatted = messageBuilder.transform({ ...messageFromS3Csv })
+		const body = JSON.parse(formatted.MessageBody)
+
+		expect(body.event_details).not.toHaveProperty('value_omitted')
+		expect(body.event_details.value_included).not.toHaveProperty('some-value')
 	})
 })

--- a/src/transformers/GovUKPayPaymentEventMessage.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.ts
@@ -39,7 +39,9 @@ function formatPaymentEventMessage(message: Message): PaymentEventMessage {
 	// put these in `event_data`
 	for (const paymentEventMessageKey in message) {
 		const paymentEventMessageValue = message[paymentEventMessageKey] && message[paymentEventMessageKey].trim()
-		formatted.event_details[paymentEventMessageKey] = paymentEventMessageValue
+		if (paymentEventMessageValue) {
+			formatted.event_details[paymentEventMessageKey] = paymentEventMessageValue
+		}
 	}
 	return formatted
 }

--- a/src/transformers/GovUKPayPaymentEventMessage.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.ts
@@ -28,7 +28,7 @@ function formatPaymentEventMessage(message: Message): PaymentEventMessage {
 
 	// initially extract the reserved properties
 	for (const reserved of reservedKeys) {
-		const reservedEntry = message[reserved.key]
+		const reservedEntry = message[reserved.key] && message[reserved.key].trim()
 		if (reservedEntry) {
 			formatted[reserved.target] = reservedEntry
 			delete message[reserved.key]
@@ -38,7 +38,8 @@ function formatPaymentEventMessage(message: Message): PaymentEventMessage {
 	// any remaining properties will override attributes of the transaction itself
 	// put these in `event_data`
 	for (const paymentEventMessageKey in message) {
-		formatted.event_details[paymentEventMessageKey] = message[paymentEventMessageKey]
+		const paymentEventMessageValue = message[paymentEventMessageKey] && message[paymentEventMessageKey].trim()
+		formatted.event_details[paymentEventMessageKey] = paymentEventMessageValue
 	}
 	return formatted
 }


### PR DESCRIPTION
Expected behaviour:
* trim inputs from individual CSV fields - these often include spaces for
readability but aren't needed in structured JSON format
* if a header is provided but the value is falsey (empty string, null)
it should not be included in the SQS message