### PR TITLE
PP-6218 Remove body details from consumer logs

### DIFF
--- a/src/consumers/SQSConsumer.ts
+++ b/src/consumers/SQSConsumer.ts
@@ -65,8 +65,6 @@ export default class SQSConsumer implements Consumer {
 					'batch_id': batchId,
 					'messages': batch.map((entry, index) => ({
 						'id': params.Entries[index].Id,
-						'primary_column': entry[Object.keys(entry)[0]],
-						'body': entry
 					})),
 					'failed': data.Failed.map((entry) => ({
 						'id': entry.Id,


### PR DESCRIPTION
Logs may contain PII, this is encrypted in S3 so it cannot be leaked,
however the Splunk logs should not include these details.

This also fixes an issue where the structured logs overflow if the body
is too large.