### PR TITLE
PP-8637 Stop adding all values to event_details as string

### DIFF
--- a/src/transformers/GovUKPayPaymentEventMessage.test.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.test.ts
@@ -11,8 +11,14 @@ describe('message formatter', () => {
 		'amount': 'some-amount',
 		'will_have_empty_space': ' some-empty-space-values ',
 		'value_omitted': '',
-		'value_included': 'some-value'
+		'value_included': 'some-value',
 	}
+
+	// @ts-ignore
+	messageFromS3Csv["boolean_value"] = true
+	// @ts-ignore
+	messageFromS3Csv["numeric_value"] = 123
+
 	const messageBuilder = new GovUKPayPaymentEventMessage()
 
 	test('correctly transforms known reserved columns', () => {
@@ -26,6 +32,8 @@ describe('message formatter', () => {
 		expect(body).toHaveProperty('event_details')
 		expect(body).toHaveProperty('event_type')
 		expect(body).toHaveProperty('reproject_domain_object', true)
+		expect(body).toHaveProperty('event_details.boolean_value', true)
+		expect(body).toHaveProperty('event_details.numeric_value', 123)
 	})
 
 	test('ignores reserved properties if not needed on transaction', () => {

--- a/src/transformers/GovUKPayPaymentEventMessage.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.ts
@@ -43,7 +43,10 @@ function formatPaymentEventMessage(message: Message): PaymentEventMessage {
 	// any remaining properties will override attributes of the transaction itself
 	// put these in `event_data`
 	for (const paymentEventMessageKey in message) {
-		const paymentEventMessageValue = message[paymentEventMessageKey] && message[paymentEventMessageKey].trim()
+
+		const paymentEventMessageValue = message[paymentEventMessageKey] &&
+			(typeof message[paymentEventMessageKey] === 'string') ? message[paymentEventMessageKey].trim() : message[paymentEventMessageKey]
+
 		if (paymentEventMessageValue) {
 
 			// support only 1 level of nesting for second level attributes


### PR DESCRIPTION
## WHAT
- Currently all values in event_details are added as string. so boolean/numeric values sent to ledger doesn't match expected datatype (ex: boolean for moto/requires_3ds).
- Changed to pass values as the intended datatype.