### PR TITLE
PP-8916: Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.22.7-alpine3.14@sha256:b00269389ee255f4129bf4af8a0a1eb3ed16fa37144c20734fb6d93e7c48f5f7
+FROM node:12.22.7-alpine3.14@sha256:3a8ee0d3482bc9139a3554821936379cac9b4a01135ca34ddcf6505b6631ce12
 COPY package.json package-lock.json ./
 RUN npm ci --no-progress
 COPY src/ src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node@sha256:a199f64c814f12fb00fa81a6e1c7f964e260a127f2b64ac526a358f3152c0f66
+FROM node:12.22.7-alpine3.14@sha256:b00269389ee255f4129bf4af8a0a1eb3ed16fa37144c20734fb6d93e7c48f5f7
 COPY package.json package-lock.json ./
 RUN npm ci --no-progress
 COPY src/ src


### PR DESCRIPTION
# What?
Update base image from alpine 3.12 to alpine 3.14

# How to test
1. Deploy to test environment
2. Trigger the container to run
3. Check the logs to ensure the csv has been read and posted to SQS

I have deployed this to test, run a job through it, and [this splunk search](https://gds.splunkcloud.com/en-GB/app/gds-004-pay/payment_update_job?form.timespan.earliest=-15m&form.timespan.latest=now&form.job_id=5ab4f026) shows the job succeeding: 

None of the changes in alpine 3.13 or 3.14 should affect us other than bringing security updates:
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0

3.14.1 includes fixes for apk-tools CVE-2021-36159
3.14.2 includes fixes for openssl CVE-2021-3711 and CVE-2021-3712.