### PR TITLE
PP-9288: Bump ajv library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,9 +1249,9 @@
       }
     },
     "ajv": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "ISC",
   "engines": {
     "node": "^12.22.10"
-  },  
+  },
   "dependencies": {
     "aws-sdk": "^2.1044.0",
     "winston": "3.2.1"


### PR DESCRIPTION
Discovered by running `npm audit fix` on master branch.