### PR TITLE
PP-9253: Run npm audit on each build and tag with alpha_release-XXX

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,21 @@
+name: Post merge
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    uses: .github/workflows/run-tests.yml@master
+
+  release:
+    if: github.ref == 'refs/heads/master'
+    needs: tests
+    name: Release
+    permissions:
+      contents: write
+    uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@master        

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/run-tests.yml
 
   release:
-    needs: test
+    needs: tests
     name: Release
     permissions:
       contents: write

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -10,11 +10,10 @@ permissions:
 
 jobs:
   tests:
-    uses: .github/workflows/run-tests.yml@master
+    uses: ./.github/workflows/run-tests.yml
 
   release:
-    if: github.ref == 'refs/heads/master'
-    needs: tests
+    needs: test
     name: Release
     permissions:
       contents: write

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,8 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
+      - name: Security audit
+        run: npm audit    
       - name: Install dependencies
         run: npm ci
       - name: Run lint

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,6 @@
 name: Github Actions Tests
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 permissions:
@@ -35,11 +32,3 @@ jobs:
         run: npm run lint
       - name: Run unit tests
         run: npm test
-
-  release:
-    if: github.ref == 'refs/heads/master'
-    needs: test
-    name: Release
-    permissions:
-      contents: write
-    uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@master        

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,7 @@ name: Github Actions Tests
 
 on:
   pull_request:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  unit-tests:
+  test:
     runs-on: ubuntu-18.04
     name: Unit tests
 
@@ -35,3 +35,11 @@ jobs:
         run: npm run lint
       - name: Run unit tests
         run: npm test
+
+  release:
+    if: github.ref == 'refs/heads/master'
+    needs: test
+    name: Release
+    permissions:
+      contents: write
+    uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@master        


### PR DESCRIPTION
`npm audit` takes about 5 seconds to run so there's no issue running it every time.

I have also manually created the [alpha_release-4 tag](https://github.com/alphagov/pay-stream-s3-sqs/tree/alpha_release-4) on github as we already have a [4-release tag on AWS Test ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/223851549868/govukpay/stream-s3-sqs?region=eu-west-1). The tag on ECR happened because up until now stream-s3-sqs images have been [manually pushed to ECR](https://pay-team-manual.cloudapps.digital/manual/how-to/ad-hoc-tasks.html#deploying-transaction-updater).