### PR TITLE
PP-9376 add concurrency group to workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -8,6 +8,8 @@ on:
 permissions:
   contents: read
 
+concurrency: stream-s3-sqs-post-merge
+
 jobs:
   tests:
     uses: ./.github/workflows/run-tests.yml

--- a/README.md
+++ b/README.md
@@ -18,4 +18,7 @@ message JSON object with the field names expected by ledger.
 | *\<transaction detail field name\>* | event_details['*\<transaction detail field name\>*'] |
 
 ## Deployment
-See https://pay-team-manual.cloudapps.digital/manual/how-to/ad-hoc-tasks.html#deploying-transaction-updater
+
+Once merged, Concourse builds the image and pushes to ECR. However the deployment is currently done manually.
+
+See https://pay-team-manual.cloudapps.digital/manual/how-to/ad-hoc-tasks.html#deploying-transaction-updater for more details.


### PR DESCRIPTION
Adds concurrency to limit the post-merge workflow runs to one-at-a-time ([see pay-stubs for naming convention](https://github.com/alphagov/pay-stubs/commit/ab8ad7ca24e5d2cc4168055d8d16325d87bfb685).