### PR TITLE
PP-9575: Update underlying node image for stream-s3-sqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-alpine3.15@sha256:5e20a4e2e52daa1743006c224f2971b1218201e284d17c6eff4a696c9020f1a2
+FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a04cf773e66960b2d75bc
 COPY package.json package-lock.json ./
 COPY src/ src
 COPY tsconfig.json tsconfig.json


### PR DESCRIPTION
This should pick up the fix for https://nvd.nist.gov/vuln/detail/CVE-2022-28391

See dockerhub https://hub.docker.com/layers/node/library/node/16.14.2-alpine3.15/images/sha256-38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a04cf773e66960b2d75bc?context=explore