### PR TITLE
PP-9873 Transform boolean values from string

### DIFF
--- a/src/transformers/GovUKPayPaymentEventMessage.test.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.test.ts
@@ -14,6 +14,11 @@ describe('message formatter', () => {
 		'will_have_empty_space': ' some-empty-space-values ',
 		'value_omitted': '',
 		'value_included': 'some-value',
+		'boolean_string_lowercase_true': 'true',
+		'boolean_string_uppercase_true': 'TRUE',
+		'boolean_string_lowercase_false': 'false',
+		'boolean_string_uppercase_false': 'FALSE',
+		'empty_column': ''
 	}
 
 	// @ts-ignore
@@ -38,6 +43,11 @@ describe('message formatter', () => {
 		expect(body).toHaveProperty('live', true)
 		expect(body).toHaveProperty('event_details.boolean_value', true)
 		expect(body).toHaveProperty('event_details.numeric_value', 123)
+		expect(body).toHaveProperty('event_details.boolean_string_lowercase_true', true)
+		expect(body).toHaveProperty('event_details.boolean_string_uppercase_true', true)
+		expect(body).toHaveProperty('event_details.boolean_string_lowercase_false', false)
+		expect(body).toHaveProperty('event_details.boolean_string_uppercase_false', false)
+		expect(body).not.toHaveProperty('empty_column')
 	})
 
 	test('ignores reserved properties if not needed on transaction', () => {

--- a/src/transformers/GovUKPayPaymentEventMessage.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.ts
@@ -48,15 +48,20 @@ function formatPaymentEventMessage(message: Message): PaymentEventMessage {
 	// put these in `event_data`
 	for (const paymentEventMessageKey in message) {
 
-		const paymentEventMessageValue = message[paymentEventMessageKey] &&
-			(typeof message[paymentEventMessageKey] === 'string') ? message[paymentEventMessageKey].trim() : message[paymentEventMessageKey]
+		let paymentEventMessageValue: any = message[paymentEventMessageKey]
+		if (typeof paymentEventMessageValue === 'string') {
+			paymentEventMessageValue = paymentEventMessageValue.trim()
+			if (paymentEventMessageValue.toLocaleLowerCase() == 'true' || paymentEventMessageValue.toLocaleLowerCase() == 'false') {
+				paymentEventMessageValue = paymentEventMessageValue.toLocaleLowerCase() == 'true'
+			}
+		}
 
-		if (paymentEventMessageValue) {
+		if (paymentEventMessageValue !== undefined && paymentEventMessageValue !== '') {
 
 			// support only 1 level of nesting for second level attributes
 			if (paymentEventMessageKey.includes('.')) {
 				const [ topLevelKey, nestedKey ] = paymentEventMessageKey.split('.')
-				const nestedObject: { [key: string]: string } = {}
+				const nestedObject: { [key: string]: any } = {}
 
 				nestedObject[nestedKey] = paymentEventMessageValue
 				formatted.event_details[topLevelKey] = nestedObject


### PR DESCRIPTION
If a CSV column value has a value that is "true", or "false", transform
this to a boolean type when creating the event to send to ledger.