### PR TITLE
BAU Ignore case when parsing bools

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
     "editor.insertSpaces": false,
     "eslint.format.enable": true,
     "[typescript]": {
-        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+        "editor.defaultFormatter": "vscode.typescript-language-features"
     }
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,4 @@ message JSON object with the field names expected by ledger.
 
 ## Deployment
 
-Once merged, Concourse builds the image and pushes to ECR. However the deployment is currently done manually.
-
-See https://pay-team-manual.cloudapps.digital/manual/how-to/ad-hoc-tasks.html#deploying-transaction-updater for more details.
+Changes are automatically deployed. See https://pay-team-manual.cloudapps.digital/manual/how-to/ad-hoc-tasks.html#deploying-transaction-updater for more details.

--- a/src/transformers/GovUKPayPaymentEventMessage.test.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.test.ts
@@ -90,4 +90,16 @@ describe('message formatter', () => {
 		expect(body.event_details.nested).toHaveProperty('value')
 		expect(body.event_details.nested.value).toBe('some-nested-value')
 	})
+
+	test('correctly parses reserved entry boolean ignoring case', () => {
+		const formatted = messageBuilder.transform({
+			'live': 'TRUE',
+			'reproject_domain_object': 'FALSE'
+		})
+		const body = JSON.parse(formatted.MessageBody)
+
+		expect(body).toHaveProperty('live', true)
+		expect(body).toHaveProperty('reproject_domain_object', false)
+	})
+
 })

--- a/src/transformers/GovUKPayPaymentEventMessage.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.ts
@@ -37,7 +37,7 @@ function formatPaymentEventMessage(message: Message): PaymentEventMessage {
 		let reservedEntry: any = message[reserved.key] && message[reserved.key].trim()
 		if (reservedEntry) {
 			if (reserved.targetBoolean) {
-				reservedEntry = reservedEntry == 'true'
+				reservedEntry = reservedEntry.toLocaleLowerCase() == 'true'
 			}
 			formatted[reserved.target] = reservedEntry
 			delete message[reserved.key]


### PR DESCRIPTION
Parse upper case boolean strings - 'TRUE'/'FALSE' as booleans when transforming CSV to transaction events.