### PR TITLE
BAU: Ignore Github config changes for post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '.github/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
If we're only making changes to `.github` workflow files (e.g. bumping versions of actions/cache) or dependabot config, then we don't want to tag the merge as a 'release'. We follow this pattern for the app repositories (see [connector as an example](https://github.com/alphagov/pay-connector/blob/master/.github/workflows/post-merge.yml#L7)).

This should mean less work for Concourse and fewer no-op deploys for the this container.