### PR TITLE
PP-10970: Dependabot config for GHA and npm security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
@@ -15,7 +15,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay


### PR DESCRIPTION
See [Github documentation for details](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates). 

This config will:
- only create security update PRs for `npm` and `github-actions` ecosystems
- create `docker` ecosystem PRs as usual (these are not always flagged as security fixes by Dependabot so these still receive 'feature' updates).