### PR TITLE
PP-11273: Run npm audit for production dependencies only

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,7 +33,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
       - name: Security audit
-        run: npm audit    
+        run: npm audit --only=prod
       - name: Install dependencies
         run: npm ci
       - name: Run lint


### PR DESCRIPTION
Currently npm audit is preventing other security updates being merged, due to currently-unpatchable dev dependencies that don't affect this component.