### PR TITLE
BAU: Ignore node upgrades over version 18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
   schedule:
     interval: weekly
     time: "03:00"
+  ignore:
+  - dependency-name: "node"
+    versions:
+    - ">= 19"
   open-pull-requests-limit: 10
   labels:
   - govuk-pay


### PR DESCRIPTION
Ignore node version bumps from node18 until we are ready to do them.