### PR TITLE
PP-12515: Bump Node to 18.20.1-alpine3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.0-alpine3.18@sha256:63008551461d4550a3567af2d56ebb624e56db93f7ef951bf2ea5f41ef63d2e4 AS builder
+FROM node:18.20.1-alpine3.19@sha256:fdaafba89e47a9716571df803d7759392b51ba7fbaddbeefdb433abbaedc25f6 AS builder
 RUN apk -U upgrade --available
 COPY package.json package-lock.json ./
 COPY src/ src


### PR DESCRIPTION
Pulls in Node security updates and the latest alpine.