### PR TITLE
PP-12687: Add Dependency Review workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,3 +43,7 @@ jobs:
 
   check-docker-base-images-are-manifests:
     uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/pay-ci/.github/workflows/_run-dependency-review.yml@master


### PR DESCRIPTION
Adds the new [dependency review workflow](https://github.com/alphagov/pay-ci/pull/1329) to pre-merge checks.