### PR TITLE
Pp 11677: Resolve usage of any type declarations

### DIFF
--- a/src/providers/Provider.ts
+++ b/src/providers/Provider.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream'
-export type Message = { [key: string]: string }
+export type MessageValue = string
+export type Message = { [key: string]: MessageValue }
 export interface ProgressPage {
 	messages: Message[];
 	progress: number;

--- a/src/transformers/GovUKPayPaymentEventMessage.test.ts
+++ b/src/transformers/GovUKPayPaymentEventMessage.test.ts
@@ -14,17 +14,14 @@ describe('message formatter', () => {
 		'will_have_empty_space': ' some-empty-space-values ',
 		'value_omitted': '',
 		'value_included': 'some-value',
+		'boolean_string_with_spaces_true': '		TruE	',
+		'boolean_string_with_spaces_false': '		fAlSE		',
 		'boolean_string_lowercase_true': 'true',
 		'boolean_string_uppercase_true': 'TRUE',
 		'boolean_string_lowercase_false': 'false',
 		'boolean_string_uppercase_false': 'FALSE',
 		'empty_column': ''
 	}
-
-	// @ts-ignore
-	messageFromS3Csv["boolean_value"] = true
-	// @ts-ignore
-	messageFromS3Csv["numeric_value"] = 123
 
 	const messageBuilder = new GovUKPayPaymentEventMessage()
 
@@ -41,8 +38,8 @@ describe('message formatter', () => {
 		expect(body).toHaveProperty('reproject_domain_object', true)
 		expect(body).toHaveProperty('service_id')
 		expect(body).toHaveProperty('live', true)
-		expect(body).toHaveProperty('event_details.boolean_value', true)
-		expect(body).toHaveProperty('event_details.numeric_value', 123)
+		expect(body).toHaveProperty('event_details.boolean_string_with_spaces_true', true)
+		expect(body).toHaveProperty('event_details.boolean_string_with_spaces_false', false)
 		expect(body).toHaveProperty('event_details.boolean_string_lowercase_true', true)
 		expect(body).toHaveProperty('event_details.boolean_string_uppercase_true', true)
 		expect(body).toHaveProperty('event_details.boolean_string_lowercase_false', false)


### PR DESCRIPTION
# What

Intention is to remove any uses of the 'any' type declaration.
Important to know all data is loaded from a CSV using S3 Select with the statement `SELECT * FROM s3Object`. Without any explicit CAST statements in the S3 Select SQL all fields are strings, always! This was actually typed correctly, but then there was quite a bit of guarding against non-strings (which is impossible).

There were also tests which set values to the number `123` and a boolean data type, this is an impossible situation.

There is code which looks for 'true' and 'false' as strings and converts them to a boolean in the transformed messages for SQS. I've kept that behaviour.

I've tried to preserve the exact original effects and side effects, while rewriting the code to be more modern typescript/javascript, and also more strictly type checked. To this end I've defined a couple of new types to make understanding the types easier.